### PR TITLE
Revise position tracking in Polymarket bot

### DIFF
--- a/POSITION_TRACKING_REVISION.md
+++ b/POSITION_TRACKING_REVISION.md
@@ -1,0 +1,202 @@
+# Position Tracking System Revision
+
+## Overview
+
+The position tracking system in the `PolymarketHourlyTradingBot` has been completely revised to properly distinguish between orders and positions, and to use actual position data from the `PolymarketClient` rather than making assumptions about order fulfillment.
+
+## Key Problems Addressed
+
+### 1. **Order vs Position Confusion**
+- **Before**: The bot created `PositionTracker` objects immediately when orders were placed, assuming all orders became positions
+- **After**: The bot now tracks orders separately from positions, only creating position trackers when orders are actually filled
+
+### 2. **No Real Position Tracking**
+- **Before**: No checks for whether orders were actually filled or what the actual position sizes were
+- **After**: Regular status checks using `PolymarketClient.get_positions()` and `get_orders()` methods
+
+### 3. **Inaccurate PnL Calculation**
+- **Before**: PnL calculations based on assumed positions from orders
+- **After**: PnL calculations based on actual position data with real entry prices and current market prices
+
+### 4. **Missing Order Status Tracking**
+- **Before**: No distinction between unfilled, partially filled, and fully filled orders
+- **After**: Comprehensive order lifecycle tracking with status updates
+
+## New Data Structures
+
+### OrderTracker
+```python
+@dataclass
+class OrderTracker:
+    """Track individual orders for lifecycle management"""
+    order_id: str
+    market_slug: str
+    token_id: str
+    token_outcome: str
+    order_price: float
+    order_size: float
+    order_time: datetime
+    predicted_direction: str
+    confidence: float
+    market_close_time: datetime
+    # Order status tracking
+    status: str = "PENDING"  # PENDING, FILLED, PARTIALLY_FILLED, CANCELLED, EXPIRED
+    filled_size: float = 0.0
+    avg_fill_price: float = 0.0
+    last_status_check: Optional[datetime] = None
+```
+
+### Enhanced PositionTracker
+```python
+@dataclass
+class PositionTracker:
+    """Track actual filled positions for P&L analysis"""
+    market_id: str
+    market_slug: str
+    token_id: str
+    token_outcome: str
+    position_size: float
+    avg_entry_price: float
+    current_price: float
+    entry_time: datetime
+    predicted_direction: str
+    confidence: float
+    market_close_time: datetime
+    # Position status
+    resolved: bool = False
+    resolution_time: Optional[datetime] = None
+    final_outcome: Optional[str] = None  # "win" or "loss"
+    pnl: Optional[float] = None
+    unrealized_pnl: Optional[float] = None
+    last_price_update: Optional[datetime] = None
+```
+
+## New Methods
+
+### Position Reconciliation
+- `reconcile_positions()`: Reconciles internal tracking with actual Polymarket positions on startup
+- `_find_market_by_token_id()`: Helper to find market information by token ID
+- `_get_token_outcome()`: Helper to get token outcome name
+- `_get_market_close_time()`: Helper to calculate market close time from slug
+
+### Order Status Management
+- `update_order_status()`: Regularly checks and updates order statuses from Polymarket
+- `check_new_positions()`: Detects new positions from filled orders
+- `cancel_expired_orders()`: Enhanced to properly update order status
+
+### Position Status Management
+- `update_position_status()`: Regularly updates position sizes and current prices
+- `calculate_unrealized_pnl()`: Calculates real-time unrealized PnL
+- `update_current_price()`: Updates position current price and recalculates PnL
+
+## Enhanced State Management
+
+### TradingState Updates
+```python
+@dataclass
+class TradingState:
+    # Order tracking (orders placed but may not be filled)
+    active_orders: Dict[str, OrderTracker] = field(default_factory=dict)
+    completed_orders: Dict[str, OrderTracker] = field(default_factory=dict)
+    
+    # Position tracking (actual filled positions)
+    open_positions: Dict[str, PositionTracker] = field(default_factory=dict)
+    resolved_positions: List[PositionTracker] = field(default_factory=list)
+    
+    # Enhanced performance tracking
+    total_unrealized_pnl: float = 0.0
+    last_position_check: Optional[datetime] = None
+    last_order_status_check: Optional[datetime] = None
+```
+
+## Key Workflow Changes
+
+### 1. Order Placement
+- **Before**: Created `PositionTracker` immediately
+- **After**: Creates `OrderTracker` and adds to `active_orders`
+
+### 2. Order Monitoring
+- **New**: Regular status checks every 30 seconds (configurable)
+- **New**: Automatic migration from `active_orders` to `completed_orders` when filled/cancelled
+
+### 3. Position Discovery
+- **New**: Checks for new positions from filled orders
+- **New**: Creates `PositionTracker` only when actual position is detected
+
+### 4. Position Monitoring
+- **New**: Regular position status updates every 60 seconds (configurable)
+- **New**: Real-time unrealized PnL calculation
+- **New**: Automatic position closure detection
+
+### 5. Performance Tracking
+- **Enhanced**: Now tracks both realized and unrealized PnL
+- **Enhanced**: Separate tracking of orders vs positions
+- **Enhanced**: More detailed performance metrics
+
+## Configuration Updates
+
+### New Configuration Options
+```python
+@dataclass
+class TradingConfig:
+    # Position tracking settings
+    position_check_interval: int = 60  # Check positions every X seconds
+    order_status_check_interval: int = 30  # Check order status every X seconds
+```
+
+## API Integration
+
+### PolymarketClient Methods Used
+- `get_positions()`: Get all positions
+- `get_positions_by_fuzzy_slug()`: Get positions filtered by market slug
+- `get_orders()`: Get current order status
+- `get_order_book()`: Get current market prices for PnL calculation
+
+## Benefits
+
+### 1. **Accuracy**
+- Real position tracking instead of assumptions
+- Accurate PnL calculation based on actual fills
+- Proper order status tracking
+
+### 2. **Risk Management**
+- Better understanding of actual exposure
+- Separation of committed capital (orders) vs invested capital (positions)
+- Real-time unrealized PnL monitoring
+
+### 3. **Performance Monitoring**
+- More accurate performance metrics
+- Better debugging and analysis capabilities
+- Comprehensive order and position history
+
+### 4. **Robustness**
+- Handles partial fills correctly
+- Recovers from disconnections by reconciling state
+- Proper error handling for API failures
+
+## Migration Notes
+
+### For Existing Bots
+1. The bot will automatically reconcile existing positions on startup
+2. Historical data format has changed - old position data may need migration
+3. New configuration options are optional (have defaults)
+
+### Data Storage
+- Enhanced JSON export includes both orders and positions
+- Separate tracking for active vs completed orders
+- More detailed position information for analysis
+
+## Testing Recommendations
+
+1. **Order Lifecycle Testing**: Test order placement, filling, and cancellation
+2. **Position Reconciliation**: Test startup reconciliation with existing positions
+3. **PnL Accuracy**: Compare calculated PnL with actual Polymarket data
+4. **Error Handling**: Test behavior when API calls fail
+5. **Performance**: Monitor performance with frequent status checks
+
+## Future Enhancements
+
+1. **Partial Fill Handling**: Enhanced support for partial order fills
+2. **Position Sizing**: Dynamic position sizing based on actual vs planned exposure
+3. **Risk Limits**: Real-time risk limit enforcement based on actual positions
+4. **Advanced Analytics**: Position performance analysis and optimization

--- a/src/polymarket_hourly_trading_bot.py
+++ b/src/polymarket_hourly_trading_bot.py
@@ -658,18 +658,18 @@ class PolymarketHourlyTradingBot:
                 return {}
 
             # Get best bid and ask
-            best_bid = float(order_book.bids[0][0]) if order_book.bids else 0.0
-            best_ask = float(order_book.asks[0][0]) if order_book.asks else 1.0
+            best_bid = float(order_book.bids[0].price) if order_book.bids else 0.0
+            best_ask = float(order_book.asks[0].price) if order_book.asks else 1.0
 
             # Calculate midpoint
             midpoint = (best_bid + best_ask) / 2
 
             # Calculate total liquidity
             bid_liquidity = sum(
-                float(price) * float(size) for price, size in order_book.bids[:5]
+                float(bid.price) * float(bid.size) for bid in order_book.bids
             ) if order_book.bids else 0.0
             ask_liquidity = sum(
-                float(price) * float(size) for price, size in order_book.asks[:5]
+                float(ask.price) * float(ask.size) for ask in order_book.asks
             ) if order_book.asks else 0.0
 
             return {

--- a/src/polymarket_hourly_trading_bot.py
+++ b/src/polymarket_hourly_trading_bot.py
@@ -349,6 +349,7 @@ class PolymarketHourlyTradingBot:
             if actual_positions:
                 for position in actual_positions:
                     if position.size > 0:  # Only track positions with actual size
+                        # NOTE: position.market_id is actually the token_id (populated from API's 'asset' field)
                         # Try to find corresponding market info
                         market = self._find_market_by_token_id(position.market_id)
                         if not market:
@@ -357,7 +358,7 @@ class PolymarketHourlyTradingBot:
                         
                         # Create position tracker
                         position_tracker = PositionTracker(
-                            market_id=position.market_id,
+                            market_id=market.condition_id,
                             market_slug=position.slug,
                             token_id=position.market_id,
                             token_outcome=self._get_token_outcome(market, position.market_id),
@@ -858,6 +859,7 @@ class PolymarketHourlyTradingBot:
             if current_positions:
                 for position in current_positions:
                     if position.size > 0 and position.market_id not in self.state.open_positions:
+                        # NOTE: position.market_id is actually the token_id (populated from API's 'asset' field)
                         # Check if we have a completed order for this position
                         corresponding_order = None
                         for order_tracker in self.state.completed_orders.values():
@@ -868,9 +870,9 @@ class PolymarketHourlyTradingBot:
                         
                         # Create position tracker
                         position_tracker = PositionTracker(
-                            market_id=position.market_id,
+                            market_id=self._find_market_by_token_id(position.market_id).condition_id if self._find_market_by_token_id(position.market_id) else "unknown",
                             market_slug=position.slug,
-                            token_id=position.market_id,
+                            token_id=position.market_id,  # position.market_id is actually token_id
                             token_outcome=self._get_token_outcome(
                                 self._find_market_by_token_id(position.market_id),
                                 position.market_id


### PR DESCRIPTION
Revise PolymarketHourlyTradingBot's position tracking to accurately reflect actual filled positions.

The previous implementation incorrectly assumed all placed orders were immediately filled positions, leading to inaccurate PnL and an incomplete view of market exposure. This PR introduces separate `OrderTracker` and `PositionTracker` classes, using `PolymarketClient`'s `get_positions` and `get_orders` methods to track actual fills and reconcile state, ensuring accurate PnL and position management.